### PR TITLE
REST clients

### DIFF
--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/EventsRestClientImpl.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/EventsRestClientImpl.java
@@ -1,88 +1,65 @@
 package com.matchbook.sdk.core.clients.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.matchbook.sdk.core.StreamObserver;
 import com.matchbook.sdk.core.clients.rest.dtos.events.Event;
 import com.matchbook.sdk.core.clients.rest.dtos.events.EventRequest;
 import com.matchbook.sdk.core.clients.rest.dtos.events.EventsRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.events.EventsResponse;
 import com.matchbook.sdk.core.clients.rest.dtos.events.Market;
 import com.matchbook.sdk.core.clients.rest.dtos.events.MarketRequest;
 import com.matchbook.sdk.core.clients.rest.dtos.events.MarketsRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.events.MarketsResponse;
 import com.matchbook.sdk.core.clients.rest.dtos.events.Runner;
 import com.matchbook.sdk.core.clients.rest.dtos.events.RunnerRequest;
 import com.matchbook.sdk.core.clients.rest.dtos.events.RunnersRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.events.RunnersResponse;
 import com.matchbook.sdk.core.clients.rest.dtos.events.Sport;
 import com.matchbook.sdk.core.clients.rest.dtos.events.SportsRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.events.SportsResponse;
 import com.matchbook.sdk.core.configs.ClientConnectionManager;
 
 public class EventsRestClientImpl extends AbstractRestClient implements EventsRestClient {
 
-    private final ObjectReader sportsResponseReader;
-    private final ObjectReader eventResponseReader;
-    private final ObjectReader eventsResponseReader;
-    private final ObjectReader marketResponseReader;
-    private final ObjectReader marketsResponseReader;
-    private final ObjectReader runnerResponseReader;
-    private final ObjectReader runnersResponseReader;
-
     public EventsRestClientImpl(ClientConnectionManager clientConnectionManager) {
         super(clientConnectionManager);
-
-        ObjectMapper objectMapper = clientConnectionManager.getMapper();
-        this.sportsResponseReader = objectMapper.readerFor(SportsResponse.class);
-        this.eventResponseReader = objectMapper.readerFor(Event.class);
-        this.eventsResponseReader = objectMapper.readerFor(EventsResponse.class);
-        this.marketResponseReader = objectMapper.readerFor(Market.class);
-        this.marketsResponseReader = objectMapper.readerFor(MarketsResponse.class);
-        this.runnerResponseReader = objectMapper.readerFor(Runner.class);
-        this.runnersResponseReader = objectMapper.readerFor(RunnersResponse.class);
     }
 
     @Override
     public void getSports(SportsRequest sportsRequest, StreamObserver<Sport> sportsObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(sportsRequest.resourcePath());
-        getRequest(url, sportsRequest.parameters(), sportsObserver, sportsResponseReader);
+        String url = getClientConfig().buildUrl(sportsRequest.resourcePath());
+        getRequest(url, sportsRequest, sportsObserver, Sport.class);
     }
 
     @Override
     public void getEvent(EventRequest eventRequest, StreamObserver<Event> eventObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(eventRequest.resourcePath());
-        getRequest(url, eventRequest.parameters(), eventObserver, eventResponseReader);
+        String url = getClientConfig().buildUrl(eventRequest.resourcePath());
+        getRequest(url, eventRequest, eventObserver, Event.class);
     }
 
     @Override
     public void getEvents(EventsRequest eventsRequest, StreamObserver<Event> eventsObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(eventsRequest.resourcePath());
-        getRequest(url, eventsRequest.parameters(), eventsObserver, eventsResponseReader);
+        String url = getClientConfig().buildUrl(eventsRequest.resourcePath());
+        getRequest(url, eventsRequest, eventsObserver, Event.class);
     }
 
     @Override
     public void getMarket(MarketRequest marketRequest, StreamObserver<Market> marketObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(marketRequest.resourcePath());
-        getRequest(url, marketRequest.parameters(), marketObserver, marketResponseReader);
+        String url = getClientConfig().buildUrl(marketRequest.resourcePath());
+        getRequest(url, marketRequest, marketObserver, Market.class);
     }
 
     @Override
     public void getMarkets(MarketsRequest marketsRequest, StreamObserver<Market> marketsObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(marketsRequest.resourcePath());
-        getRequest(url, marketsRequest.parameters(), marketsObserver, marketsResponseReader);
+        String url = getClientConfig().buildUrl(marketsRequest.resourcePath());
+        getRequest(url, marketsRequest, marketsObserver, Market.class);
     }
 
     @Override
     public void getRunner(RunnerRequest runnerRequest, StreamObserver<Runner> runnerObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(runnerRequest.resourcePath());
-        getRequest(url, runnerRequest.parameters(), runnerObserver, runnerResponseReader);
+        String url = getClientConfig().buildUrl(runnerRequest.resourcePath());
+        getRequest(url, runnerRequest, runnerObserver, Runner.class);
     }
 
     @Override
     public void getRunners(RunnersRequest runnersRequest, StreamObserver<Runner> runnersObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(runnersRequest.resourcePath());
-        getRequest(url, runnersRequest.parameters(), runnersObserver, runnersResponseReader);
+        String url = getClientConfig().buildUrl(runnersRequest.resourcePath());
+        getRequest(url, runnersRequest, runnersObserver, Runner.class);
     }
 
 }

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/PricesRestClientImpl.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/PricesRestClientImpl.java
@@ -1,26 +1,20 @@
 package com.matchbook.sdk.core.clients.rest;
 
-import com.fasterxml.jackson.databind.ObjectReader;
 import com.matchbook.sdk.core.StreamObserver;
-import com.matchbook.sdk.core.clients.rest.dtos.events.SportsResponse;
 import com.matchbook.sdk.core.clients.rest.dtos.prices.Price;
 import com.matchbook.sdk.core.clients.rest.dtos.prices.PricesRequest;
 import com.matchbook.sdk.core.configs.ClientConnectionManager;
 
 public class PricesRestClientImpl extends AbstractRestClient implements PricesRestClient {
 
-    private final ObjectReader pricesResponseReader;
-
     public PricesRestClientImpl(ClientConnectionManager clientConnectionManager) {
         super(clientConnectionManager);
-
-        this.pricesResponseReader = clientConnectionManager.getMapper().readerFor(SportsResponse.class);
     }
 
     @Override
     public void getPrices(PricesRequest pricesRequest, StreamObserver<Price> pricesObserver) {
-        String url = clientConnectionManager.getClientConfig().buildUrl(pricesRequest.resourcePath());
-        getRequest(url, pricesRequest.parameters(), pricesObserver, pricesResponseReader);
+        String url = getClientConfig().buildUrl(pricesRequest.resourcePath());
+        getRequest(url, pricesRequest, pricesObserver, Price.class);
     }
 
 }

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/UserRestClientImpl.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/UserRestClientImpl.java
@@ -1,36 +1,21 @@
 package com.matchbook.sdk.core.clients.rest;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectReader;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.matchbook.sdk.core.StreamObserver;
-import com.matchbook.sdk.core.clients.rest.dtos.user.LoginRequest;
 import com.matchbook.sdk.core.clients.rest.dtos.user.Login;
+import com.matchbook.sdk.core.clients.rest.dtos.user.LoginRequest;
 import com.matchbook.sdk.core.clients.rest.dtos.user.Logout;
 import com.matchbook.sdk.core.configs.ClientConnectionManager;
-import com.matchbook.sdk.core.exceptions.MatchbookSDKHTTPException;
 
 public class UserRestClientImpl extends AbstractRestClient implements UserRestClient {
 
-    private final ObjectWriter loginRequestWriter;
-    private final ObjectReader loginResponseReader;
-
     public UserRestClientImpl(ClientConnectionManager clientConnectionManager) {
         super(clientConnectionManager);
-
-        this.loginRequestWriter = clientConnectionManager.getMapper().writerFor(LoginRequest.class);
-        this.loginResponseReader = clientConnectionManager.getMapper().readerFor(Login.class);
     }
 
     @Override
     public void login(LoginRequest loginRequest, StreamObserver<Login> loginObserver) {
-        try {
-            String path = clientConnectionManager.getClientConfig().getLoginUrl();
-            String requestBody = loginRequestWriter.writeValueAsString(loginRequest);
-            postRequest(path, requestBody, loginObserver, loginResponseReader);
-        } catch (JsonProcessingException e) {
-            loginObserver.onError(new MatchbookSDKHTTPException((e.getCause())));
-        }
+        String url = getClientConfig().getLoginUrl();
+        postRequest(url, loginRequest, loginObserver, Login.class);
     }
 
     @Override

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/events/EventRequest.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/events/EventRequest.java
@@ -3,10 +3,10 @@ package com.matchbook.sdk.core.clients.rest.dtos.events;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.matchbook.sdk.core.clients.rest.dtos.prices.BasePricesRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.prices.BasePricesRequestBuilder;
+import com.matchbook.sdk.core.clients.rest.dtos.prices.AbstractPricesRequest;
+import com.matchbook.sdk.core.clients.rest.dtos.prices.AbstractPricesRequestBuilder;
 
-public class EventRequest extends BasePricesRequest {
+public class EventRequest extends AbstractPricesRequest {
 
     private final Long eventId;
     private final boolean includeEventParticipants;
@@ -65,7 +65,7 @@ public class EventRequest extends BasePricesRequest {
                 "}";
     }
 
-    public static class Builder extends BasePricesRequestBuilder {
+    public static class Builder extends AbstractPricesRequestBuilder {
 
         private final Long eventId;
         private boolean includeEventParticipants;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/events/MarketRequest.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/events/MarketRequest.java
@@ -3,10 +3,10 @@ package com.matchbook.sdk.core.clients.rest.dtos.events;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.matchbook.sdk.core.clients.rest.dtos.prices.BasePricesRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.prices.BasePricesRequestBuilder;
+import com.matchbook.sdk.core.clients.rest.dtos.prices.AbstractPricesRequest;
+import com.matchbook.sdk.core.clients.rest.dtos.prices.AbstractPricesRequestBuilder;
 
-public class MarketRequest extends BasePricesRequest {
+public class MarketRequest extends AbstractPricesRequest {
 
     private final Long marketId;
     private final Long eventId;
@@ -65,7 +65,7 @@ public class MarketRequest extends BasePricesRequest {
                 "}";
     }
 
-    public static class Builder extends BasePricesRequestBuilder {
+    public static class Builder extends AbstractPricesRequestBuilder {
 
         private final Long marketId;
         private final Long eventId;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/events/RunnerRequest.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/events/RunnerRequest.java
@@ -3,10 +3,10 @@ package com.matchbook.sdk.core.clients.rest.dtos.events;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.matchbook.sdk.core.clients.rest.dtos.prices.BasePricesRequest;
-import com.matchbook.sdk.core.clients.rest.dtos.prices.BasePricesRequestBuilder;
+import com.matchbook.sdk.core.clients.rest.dtos.prices.AbstractPricesRequest;
+import com.matchbook.sdk.core.clients.rest.dtos.prices.AbstractPricesRequestBuilder;
 
-public class RunnerRequest extends BasePricesRequest {
+public class RunnerRequest extends AbstractPricesRequest {
 
     private final Long runnerId;
     private final Long eventId;
@@ -73,7 +73,7 @@ public class RunnerRequest extends BasePricesRequest {
                 "}";
     }
 
-    public static class Builder extends BasePricesRequestBuilder {
+    public static class Builder extends AbstractPricesRequestBuilder {
 
         private final Long eventId;
         private final Long marketId;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/offers/AbstractMatchedBet.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/offers/AbstractMatchedBet.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 import com.matchbook.sdk.core.clients.rest.dtos.prices.Currency;
 import com.matchbook.sdk.core.clients.rest.dtos.prices.OddsType;
 
-public abstract class BaseMatchedBet {
+public abstract class AbstractMatchedBet {
 
     protected MatchedBetStatus status;
     protected OddsType oddsType;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/offers/AggregatedMatchedBet.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/offers/AggregatedMatchedBet.java
@@ -2,7 +2,7 @@ package com.matchbook.sdk.core.clients.rest.dtos.offers;
 
 import com.matchbook.sdk.core.clients.rest.dtos.prices.Side;
 
-public class AggregatedMatchedBet extends BaseMatchedBet {
+public class AggregatedMatchedBet extends AbstractMatchedBet {
 
     private Long eventId;
     private Long marketId;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/offers/MatchedBet.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/offers/MatchedBet.java
@@ -3,7 +3,7 @@ package com.matchbook.sdk.core.clients.rest.dtos.offers;
 import java.math.BigDecimal;
 import java.time.Instant;
 
-public class MatchedBet extends BaseMatchedBet {
+public class MatchedBet extends AbstractMatchedBet {
 
     private Long id;
     private Long offerId;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/prices/AbstractPricesRequest.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/prices/AbstractPricesRequest.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 
 import com.matchbook.sdk.core.clients.rest.dtos.RestRequest;
 
-public abstract class BasePricesRequest implements RestRequest {
+public abstract class AbstractPricesRequest implements RestRequest {
 
     protected final OddsType oddsType;
     protected final ExchangeType exchangeType;
@@ -16,7 +16,7 @@ public abstract class BasePricesRequest implements RestRequest {
     protected final BigDecimal minimumLiquidity;
     protected final PriceMode priceMode;
 
-    protected <B extends BasePricesRequestBuilder> BasePricesRequest(B builder) {
+    protected <B extends AbstractPricesRequestBuilder> AbstractPricesRequest(B builder) {
         this.oddsType = builder.oddsType;
         this.exchangeType = builder.exchangeType;
         this.side = builder.side;

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/prices/AbstractPricesRequestBuilder.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/prices/AbstractPricesRequestBuilder.java
@@ -2,7 +2,7 @@ package com.matchbook.sdk.core.clients.rest.dtos.prices;
 
 import java.math.BigDecimal;
 
-public abstract class BasePricesRequestBuilder {
+public abstract class AbstractPricesRequestBuilder {
 
     protected OddsType oddsType;
     protected ExchangeType exchangeType;
@@ -11,32 +11,32 @@ public abstract class BasePricesRequestBuilder {
     protected BigDecimal minimumLiquidity;
     protected PriceMode priceMode;
 
-    public BasePricesRequestBuilder oddsType(OddsType oddsType) {
+    public AbstractPricesRequestBuilder oddsType(OddsType oddsType) {
         this.oddsType = oddsType;
         return this;
     }
 
-    public BasePricesRequestBuilder exchangeType(ExchangeType exchangeType) {
+    public AbstractPricesRequestBuilder exchangeType(ExchangeType exchangeType) {
         this.exchangeType = exchangeType;
         return this;
     }
 
-    public BasePricesRequestBuilder side(Side side) {
+    public AbstractPricesRequestBuilder side(Side side) {
         this.side = side;
         return this;
     }
 
-    public BasePricesRequestBuilder currency(Currency currency) {
+    public AbstractPricesRequestBuilder currency(Currency currency) {
         this.currency = currency;
         return this;
     }
 
-    public BasePricesRequestBuilder minimumLiquidity(BigDecimal minimumLiquidity) {
+    public AbstractPricesRequestBuilder minimumLiquidity(BigDecimal minimumLiquidity) {
         this.minimumLiquidity = minimumLiquidity;
         return this;
     }
 
-    public BasePricesRequestBuilder priceMode(PriceMode priceMode) {
+    public AbstractPricesRequestBuilder priceMode(PriceMode priceMode) {
         this.priceMode = priceMode;
         return this;
     }

--- a/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/prices/PricesRequest.java
+++ b/matchbook-sdk-core/src/main/java/com/matchbook/sdk/core/clients/rest/dtos/prices/PricesRequest.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class PricesRequest extends BasePricesRequest {
+public class PricesRequest extends AbstractPricesRequest {
 
     private final Long eventId;
     private final Long marketId;
@@ -76,7 +76,7 @@ public class PricesRequest extends BasePricesRequest {
                 "}";
     }
 
-    public static class Builder extends BasePricesRequestBuilder {
+    public static class Builder extends AbstractPricesRequestBuilder {
 
         private final Long eventId;
         private final Long marketId;


### PR DESCRIPTION
A small refactor to the `AbstractRestClient`. The intent is to limit as much as possible the use of the external HTTP library to the base class of each REST client implementation.