### PR TITLE
Add cookieJar in http client to store cookies between requests

### DIFF
--- a/matchbook-sdk-rest/src/main/java/com/matchbook/sdk/rest/configs/wrappers/HttpClientWrapper.java
+++ b/matchbook-sdk-rest/src/main/java/com/matchbook/sdk/rest/configs/wrappers/HttpClientWrapper.java
@@ -73,7 +73,7 @@ public class HttpClientWrapper implements HttpClient {
                 List<Cookie> cookies = cookieStore.get(url.host());
 
                 if (cookies == null) {
-                    return new ArrayList<Cookie>();
+                    return new ArrayList<>();
                 }
 
                 final long now = System.currentTimeMillis();

--- a/matchbook-sdk-rest/src/test/java/com/matchbook/sdk/rest/clients/rest/UserClientRestTest.java
+++ b/matchbook-sdk-rest/src/test/java/com/matchbook/sdk/rest/clients/rest/UserClientRestTest.java
@@ -348,6 +348,7 @@ public class UserClientRestTest extends MatchbookSDKClientTest {
         return new StreamObserver<T>() {
             @Override
             public void onNext(T response) {
+                // do nothing
             }
 
             @Override

--- a/matchbook-sdk-rest/src/test/java/com/matchbook/sdk/rest/clients/rest/UserClientRestTest.java
+++ b/matchbook-sdk-rest/src/test/java/com/matchbook/sdk/rest/clients/rest/UserClientRestTest.java
@@ -4,15 +4,19 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
 
 import com.matchbook.sdk.core.StreamObserver;
 import com.matchbook.sdk.core.exceptions.ErrorType;
@@ -28,7 +32,6 @@ import com.matchbook.sdk.rest.dtos.user.Login;
 import com.matchbook.sdk.rest.dtos.user.LoginRequest;
 import com.matchbook.sdk.rest.dtos.user.Logout;
 import com.matchbook.sdk.rest.dtos.user.LogoutRequest;
-import org.junit.Test;
 
 public class UserClientRestTest extends MatchbookSDKClientTest {
 
@@ -245,5 +248,117 @@ public class UserClientRestTest extends MatchbookSDKClientTest {
 
         boolean await = countDownLatch.await(2, TimeUnit.SECONDS);
         assertThat(await).isTrue();
+    }
+
+    @Test
+    public void successfulLoginAndGetBalanceTest() throws InterruptedException {
+        // Perform first a login request with response that sets the session-token cookie
+        // We expect that the following GET balance includes the same cookie in the request
+
+        stubFor(post(urlEqualTo("/bpapi/rest/security/session"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withHeader("Set-Cookie", "session-token=2574_d4dcd1c54caacb4755a")
+                .withBodyFile("matchbook/loginSuccessfulResponse.json")));
+
+        stubFor(get(urlPathEqualTo("/edge/rest/account/balance"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBodyFile("matchbook/getAccountBalanceSuccessfulResponse.json")));
+
+        final CountDownLatch loginCountDownLatch = new CountDownLatch(1);
+        LoginRequest loginRequest = new LoginRequest.Builder("username".toCharArray(), "password".toCharArray())
+            .build();
+        userRestClient.login(loginRequest, buildStreamObserverWithCountdownLatch(loginCountDownLatch));
+
+        boolean await = loginCountDownLatch.await(1, TimeUnit.SECONDS);
+        assertThat(await).isTrue();
+
+        final CountDownLatch balanceCountDownLatch = new CountDownLatch(1);
+        BalanceRequest balanceRequest = new BalanceRequest.Builder().build();
+        userRestClient.getBalance(balanceRequest, buildStreamObserverWithCountdownLatch(balanceCountDownLatch));
+
+        await = balanceCountDownLatch.await(1, TimeUnit.SECONDS);
+        assertThat(await).isTrue();
+
+        verify(getRequestedFor(urlEqualTo("/edge/rest/account/balance"))
+            .withCookie("session-token", equalTo("2574_d4dcd1c54caacb4755a")));
+    }
+
+    @Test
+    public void successfulLoginAndLogoutTest() throws InterruptedException {
+        // Perform a login request with response that sets the session-token cookie
+        // then a logout request that should expire the cookie.
+        // We expect that the following GET balance doesn't include the session-token cookie
+
+        stubFor(post(urlEqualTo("/bpapi/rest/security/session"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withHeader("Set-Cookie", "session-token=2574_d4dcd1c54caacb4755a")
+                .withBodyFile("matchbook/loginSuccessfulResponse.json")));
+
+        stubFor(delete(urlEqualTo("/bpapi/rest/security/session"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withHeader("Set-Cookie", "session-token=2574_d4dcd1c54caacb4755a; Max-Age=0")
+                .withBodyFile("matchbook/logoutSuccessfulResponse.json")));
+
+        stubFor(get(urlPathEqualTo("/edge/rest/account/balance"))
+            .withHeader("Accept", equalTo("application/json"))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBodyFile("matchbook/getAccountBalanceSuccessfulResponse.json")));
+
+        final CountDownLatch loginCountDownLatch = new CountDownLatch(1);
+        LoginRequest loginRequest = new LoginRequest.Builder("username".toCharArray(), "password".toCharArray())
+            .build();
+        userRestClient.login(loginRequest, buildStreamObserverWithCountdownLatch(loginCountDownLatch));
+
+        boolean await = loginCountDownLatch.await(1, TimeUnit.SECONDS);
+        assertThat(await).isTrue();
+
+        final CountDownLatch logoutCountDownLatch = new CountDownLatch(1);
+        userRestClient.logout(new LogoutRequest.Builder().build(),
+            buildStreamObserverWithCountdownLatch(logoutCountDownLatch));
+
+        await = logoutCountDownLatch.await(1, TimeUnit.SECONDS);
+        assertThat(await).isTrue();
+
+        final CountDownLatch balanceCountDownLatch = new CountDownLatch(1);
+        BalanceRequest balanceRequest = new BalanceRequest.Builder().build();
+        userRestClient.getBalance(balanceRequest, buildStreamObserverWithCountdownLatch(balanceCountDownLatch));
+
+        await = balanceCountDownLatch.await(1, TimeUnit.SECONDS);
+        assertThat(await).isTrue();
+
+        verify(getRequestedFor(urlEqualTo("/edge/rest/account/balance"))
+            .withoutHeader("set-cookie"));
+    }
+
+    private <T> StreamObserver<T> buildStreamObserverWithCountdownLatch(CountDownLatch countDownLatch) {
+        return new StreamObserver<T>() {
+            @Override
+            public void onNext(T response) {
+            }
+
+            @Override
+            public void onError(MatchbookSDKException e) {
+                fail();
+            }
+
+            @Override
+            public void onCompleted() {
+                countDownLatch.countDown();
+            }
+        };
     }
 }


### PR DESCRIPTION
This adds an in-memory cookie storage in the http client wrapper so the client should be able to keep the session token between requests.